### PR TITLE
fix: add missing bin scripts (ml, dev-server, dev-router.php)

### DIFF
--- a/bin/dev-router.php
+++ b/bin/dev-router.php
@@ -1,0 +1,24 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PHP built-in server router – bin wrapper.
+ *
+ * Delegates to the vendor monkeyslegion-dev-server router script.
+ * The dev-server binary already looks for bin/dev-router.php first,
+ * then falls back to the vendor copy. This file ensures the
+ * composer bin reference is valid and can serve as a project-level
+ * override point.
+ */
+
+$projectRoot  = dirname(__DIR__);
+$vendorRouter = $projectRoot . '/vendor/monkeyscloud/monkeyslegion-dev-server/bin/dev-router.php';
+
+if (! is_file($vendorRouter)) {
+    fwrite(STDERR, "Error: vendor router not found. Run: composer install\n");
+    exit(1);
+}
+
+require $vendorRouter;

--- a/bin/dev-server
+++ b/bin/dev-server
@@ -1,0 +1,32 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MonkeysLegion Dev Server – bin wrapper.
+ *
+ * Delegates to the vendor monkeyslegion-dev-server package.
+ * This allows `composer serve` / `php bin/dev-server` to work
+ * regardless of whether the package is installed as a dependency.
+ */
+
+// Locate the vendor dev-server binary
+$projectRoot = dirname(__DIR__);
+$vendorBin   = $projectRoot . '/vendor/monkeyscloud/monkeyslegion-dev-server/bin/dev-server';
+
+if (! is_file($vendorBin)) {
+    fwrite(STDERR, "Error: monkeyscloud/monkeyslegion-dev-server not installed. Run: composer install\n");
+    exit(1);
+}
+
+// Forward all arguments
+$args = array_slice($argv, 1);
+$cmd  = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($vendorBin);
+foreach ($args as $arg) {
+    $cmd .= ' ' . escapeshellarg($arg);
+}
+
+$exitCode = 0;
+passthru($cmd, $exitCode);
+exit($exitCode);

--- a/bin/ml
+++ b/bin/ml
@@ -1,0 +1,41 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use MonkeysLegion\Cli\CliKernel;
+use MonkeysLegion\Framework\HttpBootstrap;
+
+/**
+ * MonkeysLegion CLI entry point (php bin/ml).
+ */
+
+// 1) Check for vendor/autoload.php
+$dir = __DIR__ . '/..';
+$candidate = $dir . '/vendor/autoload.php';
+$found = false;
+
+if (file_exists($candidate)) {
+    require_once $candidate;
+    define('ML_BASE_PATH', realpath($dir));
+    $found = true;
+}
+
+if (! $found) {
+    fwrite(STDERR, "Error: could not find vendor/autoload.php above " . __DIR__ . "\n");
+    exit(1);
+}
+
+// 2) Load your DI definitions from the project config
+$configFile = ML_BASE_PATH . '/config/app.php';
+if (! file_exists($configFile)) {
+    fwrite(STDERR, "Error: missing config/app.php at {$configFile}\n");
+    exit(1);
+}
+
+// 3) Bootstrap and run the CLI kernel
+$container = HttpBootstrap::buildContainer(base_path());
+
+/** @var CliKernel $kernel */
+$kernel = $container->get(CliKernel::class);
+exit($kernel->run($argv));


### PR DESCRIPTION
These files were declared in composer.json's bin section but never committed, causing 'Skipped installation of bin' warnings on install.

- bin/ml: CLI entry point (adapted from root-level ml file)
- bin/dev-server: wrapper delegating to vendor dev-server package
- bin/dev-router.php: wrapper loading vendor router script